### PR TITLE
move to ansible 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE=2.4
   - ANSIBLE=2.5
   - ANSIBLE=2.6
+  - ANSIBLE=2.7
 matrix:
   fast_finish: true
 install:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Deploy prometheus [pushgateway](https://github.com/prometheus/pushgateway) using
 
 ## Requirements
 
-- Ansible >= 2.4
+- Ansible >= 2.3 (It might work on previous versions, but we cannot guarantee it)
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Prometheus Pushgateway
   license: MIT
   company: none
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   role_name: pushgateway
   platforms:
     - name: Ubuntu

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{24,25,26}
+envlist = py{27}-ansible{25,26,27}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.4: ansible24
   2.5: ansible25
   2.6: ansible26
+  2.7: ansible27
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible24: ansible<2.5
     ansible25: ansible<2.6
     ansible26: ansible<2.7
+    ansible26: ansible<2.8
 commands =
     {posargs:molecule test --all --destroy always}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ deps =
     -rtest-requirements.txt
     ansible25: ansible<2.6
     ansible26: ansible<2.7
-    ansible26: ansible<2.8
+    ansible27: ansible<2.8
 commands =
     {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
[Ansible 2.7 was just released](https://github.com/ansible/ansible/releases/tag/v2.7.0) :tada:. This PR deprecates support for ansible 2.4 and introduces testing on ansible 2.7

Merging this will result in a [patch] version release.