### PR TITLE
add pushgateway_web_external_url option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `pushgateway_version` | 0.9.1 | Node exporter package version |
 | `pushgateway_web_listen_address` | "0.0.0.0:9091" | Address on which node exporter will listen |
+| `pushgateway_web_external_url` | "" | External address on which pushgateway is available. Useful when behind reverse proxy. Ex. http://example.org/pushgateway |
 | `pushgateway_persistence` | true | Enable persistence file |
 | `pushgateway_config_flags_extra` | {} | Additional configuration flags passed at startup to pushgateway binary |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 pushgateway_version: 0.9.1
 pushgateway_web_listen_address: "0.0.0.0:9091"
+pushgateway_web_external_url: ""
 
 pushgateway_persistence: true
 

--- a/templates/pushgateway.service.j2
+++ b/templates/pushgateway.service.j2
@@ -12,6 +12,9 @@ ExecStart=/usr/local/bin/pushgateway \
 {% if pushgateway_persistence %}
   --persistence.file="{{ pushgateway_persistence_dir }}/persistence" \
 {% endif %}
+{% if pushgateway_web_external_url %}
+  --web.external-url="{{ pushgateway_web_external_url }}" \
+{% endif %}
   --web.listen-address={{ pushgateway_web_listen_address }}{% for flag, flag_value in pushgateway_config_flags_extra.items() %}\
   --{{ flag }}{% if flag_value %}={{ flag_value }}{% endif %} {% endfor %}
 


### PR DESCRIPTION
I think it’s better to add separately web.external-url, for example, as done in your other repositories. To make them look alike.