### PR TITLE
Remplacing generic tags by tags relevant to the role ansible-pushgateway

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,21 +9,23 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - always
+    - pushgateway_install
+    - pushgateway_configure
 
 - import_tasks: preflight.yml
   tags:
-    - always
+    - pushgateway_install
+    - pushgateway_configure
 
 - import_tasks: install.yml
   become: true
   tags:
-    - install
+    - pushgateway_install
 
 - import_tasks: configure.yml
   become: true
   tags:
-    - configure
+    - pushgateway_configure
 
 - name: Ensure pushgateway is enabled on boot
   become: true


### PR DESCRIPTION
- The name of the tags "install" or "configure" are too generic; were
  remplaced with "pushgateway_install" and "pushgateway_configure".
- Replacing the tags "always" as the modification above remove the need
  to use this generic tag.