### PR TITLE
Move persistence_dir to defaults/ so it can be overwritten by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `pushgateway_web_listen_address` | "0.0.0.0:9091" | Address on which pushgateway will listen |
 | `pushgateway_web_external_url` | "" | External address on which pushgateway is available. Useful when behind reverse proxy. Ex. http://example.org/pushgateway |
 | `pushgateway_persistence` | true | Enable persistence file |
+| `pushgateway_persistence_dir` | "/var/lib/pushgateway" | Path to directory with persistence file |
 | `pushgateway_config_flags_extra` | {} | Additional configuration flags passed at startup to pushgateway binary |
 
 ## Example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ pushgateway_web_listen_address: "0.0.0.0:9091"
 pushgateway_web_external_url: ""
 
 pushgateway_persistence: true
+pushgateway_persistence_dir: /var/lib/pushgateway
 
 pushgateway_config_flags_extra: {}
 # pushgateway_config_flags_extra:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,7 +14,7 @@
 - name: Create the pushgateway user
   user:
     name: "{{ pushgateway_system_user }}"
-    groups: "{{ pushgateway_system_group }}"
+    group: "{{ pushgateway_system_group }}"
     append: true
     shell: /usr/sbin/nologin
     system: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,5 @@ go_arch_map:
   armv7l: 'armv7'
   armv6l: 'armv6'
 
-pushgateway_persistence_dir: /var/lib/pushgateway
 pushgateway_system_group: "pushgateway"
 pushgateway_system_user: "{{ pushgateway_system_group }}"


### PR DESCRIPTION
With this small change it's possible to keep persistence file on disk (mountpoint) that is persistent, without extra hacking.